### PR TITLE
Allow Excel#new to accept streams like Excelx#new

### DIFF
--- a/test/test_roo_excel.rb
+++ b/test/test_roo_excel.rb
@@ -1,5 +1,6 @@
 # -- encoding : utf-8 --
 require 'test_helper'
+require 'stringio'
 
 class TestRooExcel < MiniTest::Test
   def with_spreadsheet(name)
@@ -1090,4 +1091,12 @@ Sheet 3:
   #     assert_equal 'ist "e" im Nenner von H(s)', excel.cell('b', 5)
   #   end
   # end
+
+  def test_excel_via_stringio
+    io = StringIO.new(
+      File.read(File.join(TESTDIR, 'simple_spreadsheet.xls')))
+    spreadsheet = ::Roo::Spreadsheet.open(io, extension: '.xls')
+    spreadsheet.default_sheet = spreadsheet.sheets.first
+    assert_equal 'Task 1', spreadsheet.cell('f', 4)
+  end
 end


### PR DESCRIPTION
This allows a StringIO object to be passed into the
Roo::Spreadsheet.open call for .xls files (already
supported for .xlsx files).

fixes roo-rb/roo-xls/issues/6
