### PR TITLE
Read integers like integers

### DIFF
--- a/lib/roo/xls/excel.rb
+++ b/lib/roo/xls/excel.rb
@@ -212,6 +212,8 @@ module Roo
         case value_type
         when :float
           v.to_f
+        when :integer
+          v
         when :string
           v
         when :date
@@ -341,6 +343,9 @@ module Roo
       when Float, Integer, Fixnum, Bignum
         value_type = :float
         value = cell.to_f
+      when Integer, Fixnum, Bignum
+        value_type = :integer
+        value = cell
       when ::Spreadsheet::Link
         value_type = :link
         value = cell


### PR DESCRIPTION
I don't know if there's some reason behind casting integer to float, but I got the case when sometimes (in multiple documents) the column is written as string (like 'here is some string') and sometimes as integer (like '123'). For some reason I need to store it as string anyway, and a workaround like "when class == Float ..." is not a good idea I think =).
