### PR TITLE
Add Ruby 1.9.x to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 rvm:
+  - 1.9.2
+  - 1.9.3
   - 2.0.0
   - 2.1
   - ruby-head


### PR DESCRIPTION
Add Ruby 1.9.x to travis.

Unlike roo-rb/roo, roo-xls seems to work fine under Ruby 1.9.x, but I'm adding it for consistency with the pull request roo https://github.com/roo-rb/roo/pull/270/commits
