### PR TITLE
Use Roo::Tempdir.make_tempdir instead of Roo::Base.make_tmpdir

### DIFF
--- a/lib/roo/xls/excel.rb
+++ b/lib/roo/xls/excel.rb
@@ -5,6 +5,7 @@ require 'spreadsheet'
 module Roo
   # Class for handling Excel-Spreadsheets
   class Excel < Roo::Base
+    extend Roo::Tempdir
     FORMULAS_MESSAGE = 'the spreadsheet gem does not support forumulas, so roo can not.'
     CHARGUESS =
       begin
@@ -27,17 +28,16 @@ module Roo
         @workbook = ::Spreadsheet.open(filename, mode)
       else
         file_type_check(filename, '.xls', 'an Excel', file_warning, packed)
-        make_tmpdir do |tmpdir|
-          filename = download_uri(filename, tmpdir) if uri?(filename)
-          filename = open_from_stream(filename[7..-1], tmpdir) if filename.is_a?(::String) && filename[0, 7] == 'stream:'
-          filename = unzip(filename, tmpdir) if packed == :zip
+        tmpdir = self.class.make_tempdir(self, nil, nil)
+        filename = download_uri(filename, tmpdir) if uri?(filename)
+        filename = open_from_stream(filename[7..-1], tmpdir) if filename.is_a?(::String) && filename[0, 7] == 'stream:'
+        filename = unzip(filename, tmpdir) if packed == :zip
 
-          @filename = filename
-          unless File.file?(@filename)
-            fail IOError, "file #{@filename} does not exist"
-          end
-          @workbook = ::Spreadsheet.open(filename, mode)
+        @filename = filename
+        unless File.file?(@filename)
+          fail IOError, "file #{@filename} does not exist"
         end
+        @workbook = ::Spreadsheet.open(filename, mode)
       end
 
       super(filename, options)

--- a/lib/roo/xls/excel.rb
+++ b/lib/roo/xls/excel.rb
@@ -14,6 +14,8 @@ module Roo
       rescue LoadError
         false
       end
+    INTEGER = 1.class
+    BIGNUM = (1**60).class
 
     attr_reader :workbook
 
@@ -141,7 +143,7 @@ module Roo
 
     # converts name of a sheet to index (0,1,2,..)
     def sheet_no(name)
-      return name - 1 if name.is_a?(Fixnum)
+      return name - 1 if name.is_a?(INTEGER)
       i = 0
       worksheets.each do |worksheet|
         return i if name == normalize_string(worksheet.name)
@@ -338,7 +340,7 @@ module Roo
     def read_cell(row, idx)
       cell = read_cell_content(row, idx)
       case cell
-      when Float, Integer, Fixnum, Bignum
+      when Float, Integer, INTEGER, BIGNUM
         value_type = :float
         value = cell.to_f
       when ::Spreadsheet::Link

--- a/lib/roo/xls/excel_2003_xml.rb
+++ b/lib/roo/xls/excel_2003_xml.rb
@@ -3,23 +3,24 @@ require 'base64'
 require 'nokogiri'
 
 class Roo::Excel2003XML < Roo::Base
+  extend Roo::Tempdir
   # initialization and opening of a spreadsheet file
   # values for packed: :zip
   def initialize(filename, options = {})
     packed = options[:packed]
     file_warning = options[:file_warning] || :error
 
-    make_tmpdir do |tmpdir|
-      filename = download_uri(filename, tmpdir) if uri?(filename)
-      filename = unzip(filename, tmpdir) if packed == :zip
+    tmpdir = self.class.make_tempdir(self, nil, nil)
+    filename = download_uri(filename, tmpdir) if uri?(filename)
+    filename = unzip(filename, tmpdir) if packed == :zip
 
-      file_type_check(filename, '.xml', 'an Excel 2003 XML', file_warning)
-      @filename = filename
-      unless File.file?(@filename)
-        fail IOError, "file #{@filename} does not exist"
-      end
-      @doc = ::Roo::Utils.load_xml(@filename)
+    file_type_check(filename, '.xml', 'an Excel 2003 XML', file_warning)
+    @filename = filename
+    unless File.file?(@filename)
+      fail IOError, "file #{@filename} does not exist"
     end
+    @doc = ::Roo::Utils.load_xml(@filename)
+
     namespace = @doc.namespaces.select{|xmlns, urn| urn == 'urn:schemas-microsoft-com:office:spreadsheet'}.keys.last
     @namespace = (namespace.nil? || namespace.empty?) ? 'ss' : namespace.split(':').last
     super(filename, options)


### PR DESCRIPTION
Use `Roo::Tempdir.make_tempdir` instead of deprecated `Roo::Base.make_tmpdir`.

Fixes #28 
