### PR TITLE
Updates TravisCI config to use containers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ rvm:
   - ruby-head
   - jruby-19mode # JRuby in 1.9 mode
   - rbx-2
+before_install:
+  - gem update bundler
 matrix:
   allow_failures:
     - rvm: ruby-head
 bundler_args: --without local_development
-sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ matrix:
   allow_failures:
     - rvm: ruby-head
 bundler_args: --without local_development
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ rvm:
   - ruby-head
   - jruby-19mode # JRuby in 1.9 mode
   - rbx-2
-before_install:
-  - gem update bundler
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/roo-xls.gemspec
+++ b/roo-xls.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "nokogiri"
   spec.add_dependency "spreadsheet", "> 0.9.0"
 
-  spec.add_development_dependency "bundler", ">= 1.7"
+  spec.add_development_dependency "bundler", ">= 1.10"
   spec.add_development_dependency "rake", ">= 10.0"
 end


### PR DESCRIPTION
TravisCI builds are failing due to an [issue with bundler](https://github.com/bundler/bundler/issues/3558).

One of the [suggested solutions](https://github.com/bundler/bundler/issues/3558#issuecomment-171347979) was to use TravisCI's container-based infrastructure which has the added benefit of being faster.

This commit updates `.travis.yml` to use the container-based infrastructure.