### PR TITLE
Support unified Integer class in 2.4+

### DIFF
--- a/lib/roo/xls/excel.rb
+++ b/lib/roo/xls/excel.rb
@@ -141,7 +141,7 @@ module Roo
 
     # converts name of a sheet to index (0,1,2,..)
     def sheet_no(name)
-      return name - 1 if name.is_a?(Fixnum)
+      return name - 1 if name.is_a?(Integer)
       i = 0
       worksheets.each do |worksheet|
         return i if name == normalize_string(worksheet.name)
@@ -338,7 +338,7 @@ module Roo
     def read_cell(row, idx)
       cell = read_cell_content(row, idx)
       case cell
-      when Float, Integer, Fixnum, Bignum
+      when Float, Integer
         value_type = :float
         value = cell.to_f
       when ::Spreadsheet::Link


### PR DESCRIPTION
Fixes deprecation warnings in Ruby2.4
`roo-xls/lib/roo/xls/excel.rb:144: warning: constant ::Fixnum is deprecated`