### PR TITLE
Update for make_tmpdir deprecation

### DIFF
--- a/lib/roo/xls/excel.rb
+++ b/lib/roo/xls/excel.rb
@@ -27,7 +27,7 @@ module Roo
         @workbook = ::Spreadsheet.open(filename, mode)
       else
         file_type_check(filename, '.xls', 'an Excel', file_warning, packed)
-        make_tmpdir do |tmpdir|
+        Dir.mktmpdir do |tmpdir|
           filename = download_uri(filename, tmpdir) if uri?(filename)
           filename = open_from_stream(filename[7..-1], tmpdir) if filename.is_a?(::String) && filename[0, 7] == 'stream:'
           filename = unzip(filename, tmpdir) if packed == :zip

--- a/lib/roo/xls/excel.rb
+++ b/lib/roo/xls/excel.rb
@@ -1,6 +1,7 @@
 require 'roo/xls/version'
 require 'roo/base'
 require 'spreadsheet'
+require 'tmpdir'
 
 module Roo
   # Class for handling Excel-Spreadsheets

--- a/lib/roo/xls/excel_2003_xml.rb
+++ b/lib/roo/xls/excel_2003_xml.rb
@@ -9,7 +9,7 @@ class Roo::Excel2003XML < Roo::Base
     packed = options[:packed]
     file_warning = options[:file_warning] || :error
 
-    make_tmpdir do |tmpdir|
+    Dir.mktmpdir do |tmpdir|
       filename = download_uri(filename, tmpdir) if uri?(filename)
       filename = unzip(filename, tmpdir) if packed == :zip
 

--- a/lib/roo/xls/excel_2003_xml.rb
+++ b/lib/roo/xls/excel_2003_xml.rb
@@ -1,6 +1,7 @@
 require 'date'
 require 'base64'
 require 'nokogiri'
+require 'tmpdir'
 
 class Roo::Excel2003XML < Roo::Base
   # initialization and opening of a spreadsheet file


### PR DESCRIPTION
Newer versions of the [roo gem](https://github.com/roo-rb/roo) have marked the `make_tmpdir` method for deprecation. The deprecation notice suggests using `make_tempdir` in `Roo::Tempdir`, but that method is designed for using without a block (and the cleanup mechanism it uses isn't quite as robust as that used by `Dir.mktmpdir`). Since `roo-xls` only uses `make_tmpdir` in the block form, I opted to just directly use `Dir.mktmpdir`. This fixes the deprecation warnings otherwise sent to `STDOUT` by `roo`.