### PR TITLE
Bringing two tests back to life

### DIFF
--- a/test/test_excel_2003_xml.rb
+++ b/test/test_excel_2003_xml.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TestRooExcel < MiniTest::Test
+class TestExcel2013XML < MiniTest::Test
   def with_xml_spreadsheet(name)
     yield ::Roo::Excel2003XML.new(File.join(TESTDIR, "#{name}.xml"))
   end

--- a/test/test_excel_2003_xml.rb
+++ b/test/test_excel_2003_xml.rb
@@ -26,10 +26,8 @@ class TestExcel2013XML < MiniTest::Test
   def test_date_to_float_conversion
     with_xml_spreadsheet('datetime_floatconv') do |oo|
       oo.default_sheet = oo.sheets.first
-      assert_nothing_raised(NoMethodError) do
-        oo.cell('a', 1)
-        oo.cell('a', 2)
-      end
+      assert oo.cell('a', 1)
+      assert oo.cell('a', 2)
     end
   end
 

--- a/test/test_excel_2003_xml.rb
+++ b/test/test_excel_2003_xml.rb
@@ -25,6 +25,7 @@ class TestExcel2013XML < MiniTest::Test
   # This test just checks for that exception to make sure it's not raised in this case
   def test_date_to_float_conversion
     with_xml_spreadsheet('datetime_floatconv') do |oo|
+      oo.default_sheet = oo.sheets.first
       assert_nothing_raised(NoMethodError) do
         oo.cell('a', 1)
         oo.cell('a', 2)
@@ -34,6 +35,7 @@ class TestExcel2013XML < MiniTest::Test
 
   def test_ruby_spreadsheet_formula_bug
     with_xml_spreadsheet('formula_parse_error') do |oo|
+      oo.default_sheet = oo.sheets.first
       assert_equal '5026', oo.cell(2, 3)
       assert_equal '5026', oo.cell(3, 3)
     end


### PR DESCRIPTION
`test_date_to_float_conversion` and `test_ruby_spreadsheet_formula_bug` were not executed via `rake test`, because both test_excel_2003_xml.rb and test_roo_excel.rb defines the same test case `TestRooExcel`, and these two methods in the former file were overridden by the class in the latter file when being loaded via rake task.

This PR is an attempt to give another name to the test case in test_excel_2003_xml.rb, and makes all tests green.